### PR TITLE
fix: use Rapp launcher frontmatter to load standard packages in btw CLI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-* The `btw` CLI now correctly loads `datasets`, `utils`, `stats`, and `methods` by declaring them in the Rapp `#| launcher:` frontmatter rather than via `library()` calls (#181).
+* The `btw` CLI now loads `datasets`, `utils`, `stats`, and `methods` by declaring them in the Rapp `#| launcher:` frontmatter, reducing surprises for users who expect standard R packages to be available (#181).
 
 # btw 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # btw (development version)
 
+## Bug fixes
+
+* The `btw` CLI now correctly loads `datasets`, `utils`, `stats`, and `methods` by declaring them in the Rapp `#| launcher:` frontmatter rather than via `library()` calls (#181).
+
 # btw 1.2.0
 
 ## Breaking changes

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -3,9 +3,8 @@
 #| description: >
 #|   Describe R objects, documentation, and workspace state in LLM-friendly
 #|   text. Wraps btw package tools for docs, pkg, info, and cran operations.
-
-library(btw)
-library(utils)
+#| launcher:
+#|   default-packages: [base, datasets, utils, stats, methods, btw]
 
 # Global options --------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The `btw` CLI script (`exec/btw.R`) previously used `library()` calls to load `btw` and `utils`. The idiomatic Rapp approach is to declare packages via `default-packages` in the `#| launcher:` YAML frontmatter, which gets baked into the installed shell launcher by `install_pkg_cli_apps()`.

Replaces the `library()` calls with a `#| launcher:` frontmatter block that loads `base`, `datasets`, `utils`, `stats`, `methods`, and `btw` — matching R's standard default packages plus `btw`.

## Verification

Install the CLI and verify commands work correctly:

```r
btw::install_btw_cli()
```

```sh
btw docs help dplyr::mutate
```