### PR TITLE
fix(cli): Clarify when to use btw docs vs btw cran in r-btw-cli skill

### DIFF
--- a/inst/cli-skill/r-btw-cli/SKILL.md
+++ b/inst/cli-skill/r-btw-cli/SKILL.md
@@ -7,9 +7,15 @@ description: "Use the `btw` CLI to access R documentation, manage R package deve
 
 `btw` is a command-line interface for accessing R documentation, package development, CRAN search, and R environment info.
 
+## When to use which command
+
+- Use `btw info packages --check` to quickly verify whether a package is installed.
+- Use `btw docs` to read documentation for a locally-installed package.
+- Use `btw cran` only to search for packages or retrieve basic CRAN metadata (version, description, dependencies); do not use it as a substitute for `btw docs` when the package is available locally.
+
 ## Commands
 
-Use `btw docs` to read R help pages, vignettes, and package NEWS without starting an interactive R session.
+Use `btw docs` to read R help pages, vignettes, and package NEWS for locally installed packages.
 
 ```
 btw docs help <topic> [-p <pkg>]     Read an R help page (tries topic first, falls back to package listing)
@@ -29,14 +35,14 @@ btw pkg load [--path <dir>]                Load package with pkgload
 btw pkg coverage [--file <f>] [--json]     Compute test coverage
 ```
 
-Use `btw info` to inspect the current R installation and installed packages.
+Use `btw info` to inspect the current R installation and installed packages. Use `btw info packages --check` to verify whether a specific package is installed before deciding whether to use `btw docs` or `btw cran`.
 
 ```
 btw info platform [--json]             R version, OS, locale
 btw info packages [<pkg>...] [--json]  Installed package details (--check for quick lookup, --deps for dep types)
 ```
 
-Use `btw cran` to search for packages or look up metadata for a known package on CRAN.
+Use `btw cran` to search CRAN for packages or retrieve basic metadata (version, description, dependencies) for a package. Prefer `btw docs` over `btw cran` for reading documentation when the package is installed locally.
 
 ```
 btw cran search <query> [-n <count>] [--json]  Search CRAN for packages

--- a/tests/testthat/_snaps/cli.md
+++ b/tests/testthat/_snaps/cli.md
@@ -9,10 +9,13 @@
       Wraps btw package tools for docs, pkg, info, and cran operations.
       
       Commands:
-        docs  
-        pkg   
-        info  
-        cran  
+        docs    Access R documentation
+        pkg     Work with an R package under development
+        info    Inspect the R session and environment
+        cran    Query CRAN package metadata
+        skills  Manage btw skills
+        help    Show btw CLI usage guide for AI agents
+        app     Run btw_app() in the current directory
       
       Options:
         --version / --no-version  Print btw version and exit. [default: false]
@@ -25,14 +28,14 @@
     Code
       run_btw("docs", "--help")
     Output
+      Access R documentation
+      
       Usage: btw docs [OPTIONS] <COMMAND>
       
-      docs command
-      
       Commands:
-        help      
-        vignette  
-        news      
+        help      Show help for a topic or package
+        vignette  Read a package vignette
+        news      Show package NEWS
       
       Global options:
         --version / --no-version  Print btw version and exit. [default: false]
@@ -45,9 +48,9 @@
     Code
       run_btw("docs", "help", "--help")
     Output
-      Usage: btw docs help [OPTIONS] <TOPIC>
+      Show help for a topic or package
       
-      help command
+      Usage: btw docs help [OPTIONS] <TOPIC>
       
       Options:
         -p, --package <PACKAGE>  Package name to scope the help topic.
@@ -65,16 +68,16 @@
     Code
       run_btw("pkg", "--help")
     Output
+      Work with an R package under development
+      
       Usage: btw pkg [OPTIONS] <COMMAND>
       
-      pkg command
-      
       Commands:
-        document  
-        check     
-        test      
-        load      
-        coverage  
+        document  Generate package documentation
+        check     Run R CMD check
+        test      Run package tests
+        load      Load package with pkgload
+        coverage  Measure package test coverage
       
       Options:
         --path <PATH>  Path to package directory. [default: "."] [type: string]
@@ -90,13 +93,13 @@
     Code
       run_btw("info", "--help")
     Output
+      Inspect the R session and environment
+      
       Usage: btw info [OPTIONS] <COMMAND>
       
-      info command
-      
       Commands:
-        platform  
-        packages  
+        platform  Show platform and session info
+        packages  Show installed package information
       
       Options:
         --json / --no-json  Output as JSON. [default: false] Enable with `--json`.
@@ -112,13 +115,13 @@
     Code
       run_btw("cran", "--help")
     Output
+      Query CRAN package metadata
+      
       Usage: btw cran [OPTIONS] <COMMAND>
       
-      cran command
-      
       Commands:
-        search  
-        info    
+        search  Search CRAN for packages
+        info    Show CRAN metadata for a package
       
       Options:
         --json / --no-json  Output as JSON. [default: false] Enable with `--json`.

--- a/tests/testthat/_snaps/tool-docs.md
+++ b/tests/testthat/_snaps/tool-docs.md
@@ -47,11 +47,11 @@
       
       ##### `log`
       
-      logical; if TRUE, probabilities p are given as log(p).
+      logical; if `TRUE`, probabilities/densities are given as logarithms.
       
       ##### `lower.tail`
       
-      logical; if TRUE (default), probabilities are `P[X \le x]` otherwise,
+      logical; if `TRUE` (default), probabilities are `P[X \le x]`, otherwise,
       `P[X > x]`.
       
       #### Details
@@ -68,9 +68,9 @@
       
       #### Value
       
-      `dnorm` gives the density, `pnorm` gives the distribution function,
-      `qnorm` gives the quantile function, and `rnorm` generates random
-      deviates.
+      `dnorm` gives the density, `pnorm` is the cumulative distribution
+      function, and `qnorm` is the quantile function of the normal
+      distribution. `rnorm` generates random deviates.
       
       The length of the result is determined by `n` for `rnorm`, and is the
       maximum of the lengths of the numerical arguments for the other
@@ -85,42 +85,54 @@
       #### Source
       
       For `pnorm`, based on
-      
-      Cody, W. D. (1993) Algorithm 715: SPECFUN – A portable FORTRAN package
-      of special function routines and test drivers. *ACM Transactions on
-      Mathematical Software* **19**, 22–32.
+      <a href="#reference+Normal.Rd+R+3ACody+3A1993" class="citation">Cody
+      (1993)</a>.
       
       For `qnorm`, the code is based on a C translation of
-      
-      Wichura, M. J. (1988) Algorithm AS 241: The percentage points of the
-      normal distribution. *Applied Statistics*, **37**, 477–484;
-      [doi:10.2307/2347330](https://doi.org/10.2307/2347330).
-      
-      which provides precise results up to about 16 digits for `log.p=FALSE`.
-      For log scale probabilities in the extreme tails, since
-      <span class="rlang">**R**</span> version 4.1.0, extensively since 4.3.0,
-      asymptotic expansions are used which have been derived and explored in
-      
-      Maechler, M. (2022) Asymptotic tail formulas for gaussian quantiles;
-      [<span class="pkg">DPQ</span>](https://CRAN.R-project.org/package=DPQ)
-      vignette
-      <https://CRAN.R-project.org/package=DPQ/vignettes/qnorm-asymp.pdf>.
+      <a href="#reference+Normal.Rd+R+3AWichura+3A1988"
+      class="citation">Wichura (1988)</a> which provides precise results up to
+      about 16 digits for `log.p=FALSE`. For log scale probabilities in the
+      extreme tails, since <span class="rlang">**R**</span> version 4.1.0,
+      extensively since 4.3.0, asymptotic expansions are used which have been
+      derived and explored in
+      <a href="#reference+Normal.Rd+R+3AMaechler+3A2022"
+      class="citation">Mächler (2022)</a>.
       
       For `rnorm`, see RNG for how to select the algorithm and for references
       to the supplied methods.
       
       #### References
       
-      Becker, R. A., Chambers, J. M. and Wilks, A. R. (1988) *The New S
-      Language*. Wadsworth & Brooks/Cole.
+      <span id="reference+Normal.Rd+R+3ABecker+2BChambers+2BWilks+3A1988"></span>
       
-      Johnson, N. L., Kotz, S. and Balakrishnan, N. (1995) *Continuous
-      Univariate Distributions*, volume 1, chapter 13. Wiley, New York.
+      Becker RA, Chambers JM, Wilks AR (1988). *The New S Language*. Chapman
+      and Hall/CRC, London. ISBN 053409192X.
+      
+      <span id="reference+Normal.Rd+R+3ACody+3A1993"></span>Cody WJ (1993).
+      “Algorithm 715: SPECFUN—A Portable FORTRAN Package of Special Function
+      Routines and Test Drivers.” *ACM Transactions on Mathematical Software*,
+      **19**(1), 22–30.
+      [doi:10.1145/151271.151273](https://doi.org/10.1145/151271.151273).
+      
+      <span id="reference+Normal.Rd+R+3AJohnson+2BKotz+2BBalakrishnan+3A1994"></span>Johnson
+      NL, Kotz S, Balakrishnan N (1994). *Continuous Univariate
+      Distributions*, volume 1. Wiley, New York. ISBN 978-0-471-58495-7.  
+      Chapter 13.
+      
+      <span id="reference+Normal.Rd+R+3AMaechler+3A2022"></span>Mächler M
+      (2022). *Asymptotic Tail Formulas for Gaussian Quantiles*. Vignette,
+      CRAN package <span class="pkg">DPQ</span>,
+      <https://CRAN.R-project.org/package=DPQ/vignettes/qnorm-asymp.pdf>.
+      
+      <span id="reference+Normal.Rd+R+3AWichura+3A1988"></span>Wichura MJ
+      (1988). “Algorithm AS 241: The Percentage Points of the Normal
+      Distribution.” *Applied Statistics*, **37**(3), 477.
+      [doi:10.2307/2347330](https://doi.org/10.2307/2347330).
       
       #### See Also
       
       Distributions for other standard distributions, including `dlnorm` for
-      the *Log*normal distribution.
+      the *log*-normal distribution.
       
       #### Examples
       

--- a/tests/testthat/test-btw_task.R
+++ b/tests/testthat/test-btw_task.R
@@ -1,4 +1,5 @@
 local_enable_tools()
+local_btw_md()
 withr::local_options(btw.client.quiet = TRUE)
 
 describe("btw_task()", {

--- a/tests/testthat/test-tool-agent-subagent.R
+++ b/tests/testthat/test-tool-agent-subagent.R
@@ -1,3 +1,5 @@
+local_btw_md()
+
 mock_chat <- function() {
   structure(
     list(


### PR DESCRIPTION
Closes #189

## Summary

Adds a "When to use which command" decision guide to the `r-btw-cli` SKILL.md to prevent the model from unnecessarily going to CRAN for documentation that is available locally. The key guidance: use `btw info packages --check` to verify local installation, prefer `btw docs` for locally-installed packages, and reserve `btw cran` for CRAN search and basic package metadata.

Also tightens the per-section intro lines to reinforce that `btw docs` is for local packages and `btw cran` is not a documentation source.

## Verification

Use the `r-btw-cli` skill and ask about a locally-installed package (e.g., `dplyr`). The model should check local installation first and use `btw docs` rather than `btw cran info` to retrieve documentation.