### PR TITLE
feat(cli): Add `btw docs topics` to list topics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Added two new commands to the `btw` CLI: `btw app` to launch a `btw_app()` session in the current working directory and `btw skills install` to install skills from the terminal.
 
+* Added `btw docs topics <pkg>` to the `btw` CLI for discovering a package's help topics and vignettes. Use `--only help` or `--only vignettes` to limit output to one section, or `--json` for machine-readable output (#195).
+
 * Added `btw help` to the `btw` CLI, which prints the `r-btw-cli` skill — a usage guide designed for AI agents.
 
 ## Bug fixes

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -63,9 +63,6 @@ btw_docs_help <- function(topic, package) {
       )
     }
     btw_output(btw_this(btw:::as_btw_docs_topic(parts[1], parts[2])))
-  } else if (grepl("^\\{.+\\}$", topic)) {
-    pkg_name <- sub("^\\{(.+)\\}$", "\\1", topic)
-    btw_output(btw_this(btw:::as_btw_docs_package(pkg_name)))
   } else if (has_value(package)) {
     btw_output(btw_this(btw:::as_btw_docs_topic(package, topic)))
   } else {
@@ -78,6 +75,23 @@ btw_docs_help <- function(topic, package) {
     } else {
       btw_output(result)
     }
+  }
+}
+
+btw_docs_topics <- function(package, only) {
+  if (!only %in% c("", "help", "vignettes")) {
+    stop("--only must be \"help\" or \"vignettes\"", call. = FALSE)
+  }
+
+  include_help <- only == "" || only == "help"
+  include_vignettes <- only == "" || only == "vignettes"
+
+  if (include_help) {
+    btw_output(btw_this(btw:::as_btw_docs_package(package)))
+  }
+
+  if (include_vignettes) {
+    btw_output(btw_this(utils::vignette(package = package)))
   }
 }
 
@@ -243,9 +257,20 @@ switch(
     switch(
       docs_cmd <- "",
 
+      #| title: List help topics and vignettes for a package
+      topics = {
+        #| description: Package name.
+        package <- NULL
+        #| description: Limit output to "help" topics or "vignettes".
+        #| short: 'o'
+        only <- ""
+
+        tryCatch(btw_docs_topics(package, only), error = btw_error)
+      },
+
       #| title: Show help for a topic or package
       help = {
-        #| description: Help topic, package name, or {package} for package listing.
+        #| description: Help topic, or pkg::topic to scope to a specific package.
         topic <- NULL
         #| description: Package name to scope the help topic.
         #| short: 'p'

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -97,8 +97,15 @@ btw_docs_topics <- function(package, only) {
       df$title,
       df$aliases
     )
-    cat("## Help topics\n\n")
-    cat(paste(lines, collapse = "\n"), "\n")
+    cat(
+      "## Help topics\n\n",
+      lines,
+      sprintf(
+        "\nUse `btw docs help %s::<topic>` to read a help page.\n",
+        package
+      ),
+      sep = "\n"
+    )
   }
 
   if (include_vignettes) {
@@ -111,7 +118,14 @@ btw_docs_topics <- function(package, only) {
         result <- btw:::btw_tool_docs_available_vignettes_impl(package)
         df <- S7::prop(result, "extra")$data
         lines <- sprintf("* `%s` - %s", df$vignette, df$title)
-        cat(paste(lines, collapse = "\n"), "\n")
+        cat(
+          lines,
+          sprintf(
+            "\nUse `btw docs vignette %s --name <name>` to read a vignette.\n",
+            package
+          ),
+          sep = "\n"
+        )
       },
       error = function(e) {
         msg <- cli::ansi_strip(conditionMessage(e))

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -78,6 +78,16 @@ btw_docs_help <- function(topic, package) {
   }
 }
 
+format_as_yaml_rows <- function(df) {
+  rows <- lapply(seq_len(nrow(df)), function(i) {
+    paste(
+      mapply(function(key, val) paste0(key, ": ", val), names(df), df[i, ]),
+      collapse = "\n"
+    )
+  })
+  paste(rows, collapse = "\n\n")
+}
+
 btw_docs_topics <- function(package, only) {
   if (!only %in% c("", "help", "vignettes")) {
     stop("--only must be \"help\" or \"vignettes\"", call. = FALSE)
@@ -87,11 +97,18 @@ btw_docs_topics <- function(package, only) {
   include_vignettes <- only == "" || only == "vignettes"
 
   if (include_help) {
-    btw_output(btw_this(btw:::as_btw_docs_package(package)))
+    result <- btw:::btw_tool_docs_package_help_topics_impl(package)
+    df <- S7::prop(result, "extra")$data[, c("topic_id", "title")]
+    cat("## Help topics\n\n")
+    cat(format_as_yaml_rows(df), "\n")
   }
 
   if (include_vignettes) {
-    btw_output(btw_this(utils::vignette(package = package)))
+    result <- btw:::btw_tool_docs_available_vignettes_impl(package)
+    df <- S7::prop(result, "extra")$data
+    if (include_help) cat("\n")
+    cat("## Vignettes\n\n")
+    cat(format_as_yaml_rows(df), "\n")
   }
 }
 

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -78,13 +78,41 @@ btw_docs_help <- function(topic, package) {
   }
 }
 
-btw_docs_topics <- function(package, only) {
+btw_docs_topics <- function(package, only, json = FALSE) {
   if (!only %in% c("", "help", "vignettes")) {
     stop("--only must be \"help\" or \"vignettes\"", call. = FALSE)
   }
 
   include_help <- only == "" || only == "help"
   include_vignettes <- only == "" || only == "vignettes"
+
+  if (json) {
+    out <- list()
+
+    if (include_help) {
+      result <- btw:::btw_tool_docs_package_help_topics_impl(package)
+      df <- S7::prop(result, "extra")$data
+      out$help <- lapply(seq_len(nrow(df)), function(i) {
+        list(topic_id = df$topic_id[[i]], title = df$title[[i]], aliases = df$aliases[[i]])
+      })
+    }
+
+    if (include_vignettes) {
+      out$vignettes <- tryCatch(
+        {
+          result <- btw:::btw_tool_docs_available_vignettes_impl(package)
+          df <- S7::prop(result, "extra")$data
+          lapply(seq_len(nrow(df)), function(i) {
+            list(vignette = df$vignette[[i]], title = df$title[[i]])
+          })
+        },
+        error = function(e) list()
+      )
+    }
+
+    btw_json_output(out)
+    return(invisible(NULL))
+  }
 
   if (include_help) {
     result <- btw:::btw_tool_docs_package_help_topics_impl(package)
@@ -304,8 +332,10 @@ switch(
         #| description: Limit output to "help" topics or "vignettes".
         #| short: 'o'
         only <- ""
+        #| description: Output as JSON with top-level keys "help" (array of {topic_id, title, aliases[]}) and "vignettes" (array of {vignette, title}).
+        json <- FALSE
 
-        tryCatch(btw_docs_topics(package, only), error = btw_error)
+        tryCatch(btw_docs_topics(package, only, json), error = btw_error)
       },
 
       #| title: Show help for a topic or package

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -91,13 +91,7 @@ btw_docs_topics <- function(package, only) {
     df <- S7::prop(result, "extra")$data
     lines <- mapply(
       function(topic_id, title, aliases) {
-        other <- aliases[aliases != topic_id]
-        also <- if (length(other) > 0) {
-          paste0(" *(also: ", paste(other, collapse = ", "), ")*")
-        } else {
-          ""
-        }
-        paste0("* `", topic_id, "`", also, " - ", title)
+        sprintf("* `%s` - %s", topic_id, title)
       },
       df$topic_id,
       df$title,
@@ -116,7 +110,7 @@ btw_docs_topics <- function(package, only) {
       {
         result <- btw:::btw_tool_docs_available_vignettes_impl(package)
         df <- S7::prop(result, "extra")$data
-        lines <- paste0("* `", df$vignette, "` - ", df$title)
+        lines <- sprintf("* `%s` - %s", df$vignette, df$title)
         cat(paste(lines, collapse = "\n"), "\n")
       },
       error = function(e) {

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -78,14 +78,8 @@ btw_docs_help <- function(topic, package) {
   }
 }
 
-format_as_yaml_rows <- function(df) {
-  rows <- lapply(seq_len(nrow(df)), function(i) {
-    paste(
-      mapply(function(key, val) paste0(key, ": ", val), names(df), df[i, ]),
-      collapse = "\n"
-    )
-  })
-  paste(rows, collapse = "\n\n")
+format_as_md_list <- function(df) {
+  paste0("* `", df[[1]], "` - ", df[[2]], collapse = "\n")
 }
 
 btw_docs_topics <- function(package, only) {
@@ -100,7 +94,7 @@ btw_docs_topics <- function(package, only) {
     result <- btw:::btw_tool_docs_package_help_topics_impl(package)
     df <- S7::prop(result, "extra")$data[, c("topic_id", "title")]
     cat("## Help topics\n\n")
-    cat(format_as_yaml_rows(df), "\n")
+    cat(format_as_md_list(df), "\n")
   }
 
   if (include_vignettes) {
@@ -108,7 +102,7 @@ btw_docs_topics <- function(package, only) {
     df <- S7::prop(result, "extra")$data
     if (include_help) cat("\n")
     cat("## Vignettes\n\n")
-    cat(format_as_yaml_rows(df), "\n")
+    cat(format_as_md_list(df), "\n")
   }
 }
 

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -108,14 +108,22 @@ btw_docs_topics <- function(package, only) {
   }
 
   if (include_vignettes) {
-    result <- btw:::btw_tool_docs_available_vignettes_impl(package)
-    df <- S7::prop(result, "extra")$data
-    lines <- paste0("* `", df$vignette, "` - ", df$title)
     if (include_help) {
       cat("\n")
     }
     cat("## Vignettes\n\n")
-    cat(paste(lines, collapse = "\n"), "\n")
+    tryCatch(
+      {
+        result <- btw:::btw_tool_docs_available_vignettes_impl(package)
+        df <- S7::prop(result, "extra")$data
+        lines <- paste0("* `", df$vignette, "` - ", df$title)
+        cat(paste(lines, collapse = "\n"), "\n")
+      },
+      error = function(e) {
+        msg <- cli::ansi_strip(conditionMessage(e))
+        cat(msg, "\n")
+      }
+    )
   }
 }
 

--- a/exec/btw.R
+++ b/exec/btw.R
@@ -78,10 +78,6 @@ btw_docs_help <- function(topic, package) {
   }
 }
 
-format_as_md_list <- function(df) {
-  paste0("* `", df[[1]], "` - ", df[[2]], collapse = "\n")
-}
-
 btw_docs_topics <- function(package, only) {
   if (!only %in% c("", "help", "vignettes")) {
     stop("--only must be \"help\" or \"vignettes\"", call. = FALSE)
@@ -92,17 +88,34 @@ btw_docs_topics <- function(package, only) {
 
   if (include_help) {
     result <- btw:::btw_tool_docs_package_help_topics_impl(package)
-    df <- S7::prop(result, "extra")$data[, c("topic_id", "title")]
+    df <- S7::prop(result, "extra")$data
+    lines <- mapply(
+      function(topic_id, title, aliases) {
+        other <- aliases[aliases != topic_id]
+        also <- if (length(other) > 0) {
+          paste0(" *(also: ", paste(other, collapse = ", "), ")*")
+        } else {
+          ""
+        }
+        paste0("* `", topic_id, "`", also, " - ", title)
+      },
+      df$topic_id,
+      df$title,
+      df$aliases
+    )
     cat("## Help topics\n\n")
-    cat(format_as_md_list(df), "\n")
+    cat(paste(lines, collapse = "\n"), "\n")
   }
 
   if (include_vignettes) {
     result <- btw:::btw_tool_docs_available_vignettes_impl(package)
     df <- S7::prop(result, "extra")$data
-    if (include_help) cat("\n")
+    lines <- paste0("* `", df$vignette, "` - ", df$title)
+    if (include_help) {
+      cat("\n")
+    }
     cat("## Vignettes\n\n")
-    cat(format_as_md_list(df), "\n")
+    cat(paste(lines, collapse = "\n"), "\n")
   }
 }
 
@@ -453,7 +466,9 @@ switch(
   #| title: Show btw CLI usage guide for AI agents
   help = {
     skill_path <- system.file(
-      "cli-skill", "r-btw-cli", "SKILL.md",
+      "cli-skill",
+      "r-btw-cli",
+      "SKILL.md",
       package = "btw"
     )
     if (!nzchar(skill_path)) {

--- a/inst/cli-skill/r-btw-cli/SKILL.md
+++ b/inst/cli-skill/r-btw-cli/SKILL.md
@@ -18,11 +18,11 @@ description: "Use the `btw` CLI to access R documentation, manage R package deve
 Use `btw docs` to read R help pages, vignettes, and package NEWS for locally installed packages.
 
 ```
-btw docs help <topic> [-p <pkg>]     Read an R help page (tries topic first, falls back to package listing)
-btw docs help {<pkg>}                List help topics for a package
-btw docs help <pkg>::<topic>         Read a specific help page (scoped)
-btw docs vignette <pkg> [-n <name>]  Read a vignette (--list to list available)
-btw docs news <pkg> [-s <term>]      Read package NEWS/changelog
+btw docs topics <pkg> [--only help|vignettes]  List help topics and vignettes for a package
+btw docs help <topic> [-p <pkg>]               Read an R help page
+btw docs help <pkg>::<topic>                   Read a specific help page (scoped)
+btw docs vignette <pkg> [-n <name>]            Read a vignette (--list to list available)
+btw docs news <pkg> [-s <term>]               Read package NEWS/changelog
 ```
 
 Use `btw pkg` to run development tasks on an R package under active development.

--- a/tests/testthat/_snaps/cli.md
+++ b/tests/testthat/_snaps/cli.md
@@ -33,6 +33,7 @@
       Usage: btw docs [OPTIONS] <COMMAND>
       
       Commands:
+        topics    List help topics and vignettes for a package
         help      Show help for a topic or package
         vignette  Read a package vignette
         news      Show package NEWS
@@ -61,7 +62,7 @@
                                   Enable with `--version`.
       
       Arguments:
-        <TOPIC>  Help topic, package name, or {package} for package listing.
+        <TOPIC>  Help topic, or pkg::topic to scope to a specific package.
 
 # btw pkg --help shows pkg group help
 
@@ -131,4 +132,24 @@
                                   Enable with `--version`.
       
       For help with a specific command, run: `btw cran <command> --help`.
+
+# btw docs topics --help shows topics subcommand usage
+
+    Code
+      run_btw("docs", "topics", "--help")
+    Output
+      List help topics and vignettes for a package
+      
+      Usage: btw docs topics [OPTIONS] <PACKAGE>
+      
+      Options:
+        -o, --only <ONLY>  Limit output to "help" topics or "vignettes".
+                           [default: ""] [type: string]
+      
+      Global options:
+        --version / --no-version  Print btw version and exit. [default: false]
+                                  Enable with `--version`.
+      
+      Arguments:
+        <PACKAGE>  Package name.
 

--- a/tests/testthat/_snaps/cli.md
+++ b/tests/testthat/_snaps/cli.md
@@ -133,23 +133,3 @@
       
       For help with a specific command, run: `btw cran <command> --help`.
 
-# btw docs topics --help shows topics subcommand usage
-
-    Code
-      run_btw("docs", "topics", "--help")
-    Output
-      List help topics and vignettes for a package
-      
-      Usage: btw docs topics [OPTIONS] <PACKAGE>
-      
-      Options:
-        -o, --only <ONLY>  Limit output to "help" topics or "vignettes".
-                           [default: ""] [type: string]
-      
-      Global options:
-        --version / --no-version  Print btw version and exit. [default: false]
-                                  Enable with `--version`.
-      
-      Arguments:
-        <PACKAGE>  Package name.
-

--- a/tests/testthat/test-cli.R
+++ b/tests/testthat/test-cli.R
@@ -123,10 +123,6 @@ test_that("btw docs help errors for unknown topic", {
 
 # docs topics ----------------------------------------------------------
 
-test_that("btw docs topics --help shows topics subcommand usage", {
-  expect_snapshot(run_btw("docs", "topics", "--help"))
-})
-
 test_that("btw docs topics <package> shows topics and vignettes", {
   env <- run_btw_quietly("docs", "topics", "stats")
   expect_equal(env$package, "stats")

--- a/tests/testthat/test-cli.R
+++ b/tests/testthat/test-cli.R
@@ -81,12 +81,6 @@ test_that("btw docs help <topic> resolves topic first", {
   expect_equal(env$package, "")
 })
 
-test_that("btw docs help {package} lists help topics", {
-  env <- run_btw_quietly("docs", "help", "{stats}")
-  expect_true(is.environment(env))
-  expect_equal(env$topic, "{stats}")
-  expect_equal(env$package, "")
-})
 
 test_that("btw docs help <topic> -p <package> reads help page", {
   local_skip_pandoc_convert_text()
@@ -124,6 +118,32 @@ test_that("btw docs help errors for unknown topic", {
   result <- run_btw_subprocess("docs", "help", "completely_nonexistent_xyz")
   expect_equal(result$status, 1)
   expect_match(result$stderr, "completely_nonexistent_xyz", ignore.case = TRUE)
+})
+
+
+# docs topics ----------------------------------------------------------
+
+test_that("btw docs topics --help shows topics subcommand usage", {
+  expect_snapshot(run_btw("docs", "topics", "--help"))
+})
+
+test_that("btw docs topics <package> shows topics and vignettes", {
+  env <- run_btw_quietly("docs", "topics", "stats")
+  expect_equal(env$package, "stats")
+  expect_equal(env$only, "")
+})
+
+test_that("btw docs topics --only help shows only help topics", {
+  env <- run_btw_quietly("docs", "topics", "stats", "--only", "help")
+  expect_equal(env$package, "stats")
+  expect_equal(env$only, "help")
+})
+
+test_that("btw docs topics --only vignettes shows only vignettes", {
+  skip_if_not_installed("dplyr")
+  env <- run_btw_quietly("docs", "topics", "dplyr", "--only", "vignettes")
+  expect_equal(env$package, "dplyr")
+  expect_equal(env$only, "vignettes")
 })
 
 # docs vignette ----------------------------------------------------------


### PR DESCRIPTION
```
❯ btw docs topics --help
List help topics and vignettes for a package

Usage: btw docs topics [OPTIONS] <PACKAGE>

Options:
  -o, --only <ONLY>   Limit output to "help" topics or "vignettes".
                      [default: ""] [type: string]
  --json / --no-json  Output as JSON with top-level keys "help" (array of
                      {topic_id, title, aliases[]}) and "vignettes" (array of
                      {vignette, title}).
                      [default: false]
                      Enable with `--json`.

Global options:
  --version / --no-version  Print btw version and exit. [default: false]
                            Enable with `--version`.

Arguments:
  <PACKAGE>  Package name.
```


```bash
btw docs topics dplyr
```

```
## Help topics


* `across` - Apply a function (or functions) across multiple columns
* `all_equal` - Flexible equality comparison for data frames
* `all_vars` - Apply predicate to all variables
* `args_by` - Helper for consistent documentation of '.by'
* `arrange` - Order rows using column values
* `arrange_all` - Arrange rows by a selection of variables
* `auto_copy` - Copy tables to same source, if necessary
* `backend_dbplyr` - Database and SQL generics.
* `band_members` - Band membership
* `base` - dplyr <-> base R
* `between` - Detect where values fall in a specified range
* `bind_cols` - Bind multiple data frames by column
* `bind_rows` - Bind multiple data frames by row
* `c_across` - Combine values from multiple columns
* `case-and-replace-when` - A general vectorised if-else
* `case_match` - A general vectorised 'switch()'
* `check_dbplyr` - dbplyr compatibility functions
* `coalesce` - Find the first non-missing element
* `colwise` - Column-wise operations
* `common_by` - Extract out common by variables
* `compute` - Force computation of a database query
* `consecutive_id` - Generate a unique identifier for consecutive combinations
* `context` - Information about the "current" group or variable
* `copy_to` - Copy a local data frame to a remote src
* `count` - Count the observations in each group
* `cross_join` - Cross join
* `cumall` - Cumulative versions of any, all, and mean
* `defunct` - Defunct functions
* `defunct-each` - Defunct functions for working with multiple columns
* `defunct-lazyeval` - Defunct standard evaluation functions
* `deprec-context` - Information about the "current" group or variable
* `desc` - Descending order
* `dim_desc` - Describing dimensions
* `distinct` - Keep distinct/unique rows
* `distinct_all` - Select distinct rows by a selection of variables
* `distinct_prepare` - Prepare for grouping and other operations
* `do` - Do anything
* `dplyr` - Introduction to dplyr
* `dplyr-locale` - Locale used by 'arrange()'
* `dplyr-package` - dplyr: A Grammar of Data Manipulation
* `dplyr_by` - Per-operation grouping with '.by'/'by'
* `dplyr_data_masking` - Data-masking
* `dplyr_extending` - Extending dplyr with new data frame subclasses
* `dplyr_tidy_select` - Argument type: tidy-select
* `explain` - Explain details of a tbl
* `filter` - Keep or drop rows that match a condition
* `filter-joins` - Filtering joins
* `filter_all` - Filter within a selection of variables
* `funs` - Create a list of function calls
* `glimpse` - Get a glimpse of your data
* `group_by` - Group by one or more variables
* `group_by_all` - Group by a selection of variables
* `group_by_drop_default` - Default value for .drop argument of group_by
* `group_cols` - Select grouping variables
* `group_data` - Grouping metadata
* `group_map` - Apply a function to each group
* `group_nest` - Nest a tibble using a grouping specification
* `group_split` - Split data frame by groups
* `group_trim` - Trim grouping structure
* `grouped_df` - A grouped data frame.
* `grouping` - Grouped data
* `ident` - Flag a character vector as SQL identifiers
* `if_else` - Vectorised if-else
* `in-packages` - Using dplyr in packages
* `join_by` - Join specifications
* `last_dplyr_warnings` - Show warnings from the last command
* `lead-lag` - Compute lagged or leading values
* `make_tbl` - Create a "tbl" object
* `mutate` - Create, modify, and delete columns
* `mutate-joins` - Mutating joins
* `mutate_all` - Mutate multiple columns
* `n_distinct` - Count unique combinations
* `na_if` - Convert values to 'NA'
* `near` - Compare two numeric vectors
* `nest_by` - Nest by one or more variables
* `nest_join` - Nest join
* `new_grouped_df` - Low-level construction and validation for the grouped_df and rowwise_df classes
* `nth` - Extract the first, last, or nth value from a vector
* `ntile` - Bucket a numeric vector into 'n' groups
* `order_by` - A helper function for ordering window function output
* `percent_rank` - Proportional ranking functions
* `pick` - Select a subset of columns
* `programming` - Programming with dplyr
* `progress_estimated` - Progress bar with estimated time.
* `pull` - Extract a single column
* `recode` - Recode values
* `recode-and-replace-values` - Recode and replace values
* `recoding-replacing` - Recoding columns and replacing values
* `reexports` - Objects exported from other packages
* `reframe` - Transform each group to an arbitrary number of rows
* `relocate` - Change column order
* `rename` - Rename columns
* `row_number` - Integer ranking functions
* `rows` - Manipulate individual rows
* `rowwise` - Group input by rows
* `same_src` - Figure out if two sources are the same (or two tbl have the same source)
* `sample_n` - Sample n rows from a table
* `scoped` - Operate on a selection of variables
* `select` - Keep or drop columns using their names and types
* `select_all` - Select and rename a selection of variables
* `setops` - Set operations
* `slice` - Subset rows using their positions
* `sql` - SQL escaping.
* `src` - Create a "src" object
* `src_tbls` - List all tbls provided by a source.
* `starwars` - Starwars characters
* `storms` - Storm tracks data
* `summarise` - Summarise each group down to one row
* `summarise_all` - Summarise multiple columns
* `tbl` - Create a table from a data source
* `tbl_ptype` - Return a prototype of a tbl
* `tbl_vars` - List variables provided by a tbl.
* `tidyeval-compat` - Other tidy eval tools
* `top_n` - Select top (or bottom) n rows (by value)
* `transmute` - Create, modify, and delete columns
* `two-table` - Two-table verbs
* `vars` - Select variables
* `when-any-all` - Elementwise 'any()' and 'all()'
* `window-functions` - Window functions
* `with_groups` - Perform an operation with temporary groups
* `with_order` - Run a function with one order, translating result back to original order

Use `btw docs help dplyr::<topic>` to read a help page.


## Vignettes

* `colwise` - Column-wise operations
* `base` - dplyr <-> base R
* `grouping` - Grouped data
* `dplyr` - Introduction to dplyr
* `programming` - Programming with dplyr
* `recoding-replacing` - Recoding columns and replacing values
* `rowwise` - Row-wise operations
* `two-table` - Two-table verbs
* `in-packages` - Using dplyr in packages
* `window-functions` - Window functions

Use `btw docs vignette dplyr --name <name>` to read a vignette.
```